### PR TITLE
Remove duplicate common_tags variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -14,10 +14,6 @@ variable "location" {
   default = "UK South"
 }
 
-variable "common_tags" {
-  type = "map"
-}
-
 variable "shutterPageDirectory" {
     type    = "string"
     default = "shutterPages"


### PR DESCRIPTION
A quick fix to remove a duplicate common_tags variable in variables.tf