### PR TITLE
Specify azurerm provider version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+provider "azurerm" {
+  version = "1.22.1"
+}
+
 locals {
   tags = "${merge(var.common_tags,
     map("Team Contact", "#sscs")


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-5209

### Change description ###

Specifying the AzureRm version resolves the issue of incompatible API versions when creating Topics.
