### PR TITLE
Lock azurerm provider to version 1.19

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -9,5 +9,10 @@ Environment environment = new Environment(env)
 onMaster {
   sharedInfrastructurePipeline('sscs', environment.nonProdName, 'nonprod')
   sharedInfrastructurePipeline('sscs', environment.demoName, 'nonprod')
+  sharedInfrastructurePipeline('sscs', environment.hmctsDemoName, 'hmctsdemo')
   sharedInfrastructurePipeline('sscs', environment.prodName, 'prod')
+}
+
+onHMCTSDemo {
+  sharedInfrastructurePipeline('sscs', environment.hmctsDemoName, 'hmctsdemo')
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "1.22.1"
+  version = "1.19.0"
 }
 
 locals {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-5209

### Change description ###

Version 1.19 of the azurerm provider is the version prior to the switch to the 2018-05-01 policy api, which appears to be causing the issue when creating the topic in the shared infrastructure build (everywhere except the master branch, curiously) - so we want to merge this to master in order to find the truth of it.