### PR TITLE
Make topic name more explicit

### DIFF
--- a/servicebus.tf
+++ b/servicebus.tf
@@ -9,7 +9,7 @@ module "servicebus-namespace" {
 
 module "evidenceshare-topic" {
   source                = "git@github.com:hmcts/terraform-module-servicebus-topic.git"
-  name                  = "evidenceshare"
+  name                  = "${var.product}-evidenceshare-topic-${var.env}"
   namespace_name        = "${module.servicebus-namespace.name}"
   resource_group_name   = "${azurerm_resource_group.rg.name}"
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/SSCS-5209

Making the topic name more explicit. The build is failing because a queue exists with the same name as the topic we are trying to create.