### PR TITLE
Name fix for SSCS alert

### DIFF
--- a/alerts.tf
+++ b/alerts.tf
@@ -3,7 +3,7 @@ module "sscs-fail-alert" {
   location          = "${azurerm_application_insights.appinsights.location}"
   app_insights_name = "${azurerm_application_insights.appinsights.name}"
 
-  alert_name                 = "sscs-tribunals-case-api-fail-alert"
+  alert_name                 = "sscs-fail-alert"
   alert_desc                 = "Triggers when an SSCS exception is received in a 5 minute poll."
   app_insights_query         = "exceptions | where notempty(client_Browser)"
   frequency_in_minutes       = 5


### PR DESCRIPTION
The SSCS app insights alert was incorrectly named as it it were specific to Tribunals API.