### PR TITLE
Fix zone_redundant input

### DIFF
--- a/servicebus.tf
+++ b/servicebus.tf
@@ -14,7 +14,7 @@ module "servicebus-namespace" {
   env                 = var.env
   common_tags         = local.tags
   sku                 = "Premium"
-  zoneRedundant       = true
+  zone_redundant       = true
   capacity            = 1
 }
 

--- a/state.tf
+++ b/state.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.25"
+      version = "~> 2.99.0"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
### Change description ###
The `zoneRedundant` variable has been update to `zone_redundant` to follow the correct way to name variables in terraform 

https://www.terraform-best-practices.com/naming#general-conventions



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
