### PR TITLE
DTSPO-6371 - add private endpoint provider to service bus module

### DIFF
--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,5 +1,5 @@
 tribunals_frontend_external_hostname = "sscs-tribunals-frontend-aat.service.core-compute-aat.internal"
 
-external_cert_vault_uri = "https://infra-vault-nonprod.vault.azure.net/"
+external_cert_vault_uri               = "https://infra-vault-nonprod.vault.azure.net/"
 tribunals_frontend_external_cert_name = "core-compute-aat"
 

--- a/action-groups.tf
+++ b/action-groups.tf
@@ -1,5 +1,5 @@
 data "azurerm_key_vault_secret" "sscs_failure_email_secret" {
-  name      = "sscs-failure-email-to"
+  name         = "sscs-failure-email-to"
   key_vault_id = module.sscs-vault.key_vault_id
 }
 

--- a/demo.tfvars
+++ b/demo.tfvars
@@ -1,4 +1,4 @@
 tribunals_frontend_external_hostname = "sscs-tribunals-frontend-demo.service.core-compute-demo.internal"
 
-external_cert_vault_uri = "https://infra-vault-nonprod.vault.azure.net/"
+external_cert_vault_uri               = "https://infra-vault-nonprod.vault.azure.net/"
 tribunals_frontend_external_cert_name = "core-compute-demo"

--- a/ithc.tfvars
+++ b/ithc.tfvars
@@ -1,4 +1,4 @@
 tribunals_frontend_external_hostname = "sscs-tribunals-frontend.ithc.platform.hmcts.net"
 
-external_cert_vault_uri = "https://infra-vault-qa.vault.azure.net/"
+external_cert_vault_uri               = "https://infra-vault-qa.vault.azure.net/"
 tribunals_frontend_external_cert_name = "wildcard-ithc-platform-hmcts-net"

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -10,7 +10,7 @@ module "sscs-vault" {
   common_tags             = local.tags
   location                = var.location
 
-  create_managed_identity    = true
+  create_managed_identity = true
 }
 
 output "vaultName" {

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,13 @@ provider "azurerm" {
   features {}
 }
 
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "private-endpoint"
+  subscription_id            = var.aks_subscription_id
+}
+
 locals {
   tags = "${
     merge(
@@ -10,7 +17,7 @@ locals {
         "Team Contact", "#sscs",
         "Team Name", "SSCS Team"
       )
-    )}"
+  )}"
 }
 resource "azurerm_resource_group" "rg" {
   name     = "${var.product}-${var.env}"

--- a/perftest.tfvars
+++ b/perftest.tfvars
@@ -1,5 +1,5 @@
 tribunals_frontend_external_hostname = "benefit-appeal.perftest.platform.hmcts.net"
 
-external_cert_vault_uri = "https://infra-vault-qa.vault.azure.net/"
+external_cert_vault_uri               = "https://infra-vault-qa.vault.azure.net/"
 tribunals_frontend_external_cert_name = "wildcard-perftest-platform-hmcts-net"
 

--- a/prod.tfvars
+++ b/prod.tfvars
@@ -1,4 +1,4 @@
 tribunals_frontend_external_hostname = "www.appeal-benefit-decision.service.gov.uk"
 
-external_cert_vault_uri = "https://infra-vault-prod.vault.azure.net/"
+external_cert_vault_uri               = "https://infra-vault-prod.vault.azure.net/"
 tribunals_frontend_external_cert_name = "core-compute-prod"

--- a/servicebus.tf
+++ b/servicebus.tf
@@ -7,6 +7,9 @@ locals {
 }
 
 module "servicebus-namespace" {
+  providers = {
+    azurerm.private-endpoint = azurerm.private-endpoint
+  }
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"
   name                = local.servicebus_namespace_name
   location            = var.location
@@ -14,7 +17,7 @@ module "servicebus-namespace" {
   env                 = var.env
   common_tags         = local.tags
   sku                 = "Premium"
-  zone_redundant       = true
+  zone_redundant      = true
   capacity            = 1
 }
 
@@ -23,22 +26,22 @@ module "evidenceshare-topic" {
   name                                    = local.evidenceshare_topic_name
   namespace_name                          = local.servicebus_namespace_name
   resource_group_name                     = local.resource_group_name
-  requires_duplicate_detection            =  true
+  requires_duplicate_detection            = true
   duplicate_detection_history_time_window = "PT60M"
 }
 
 module "evidenceshare-subscription" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=master"
-  name                  = local.evidenceshare_subscription_name
-  namespace_name        = local.servicebus_namespace_name
-  resource_group_name   = local.resource_group_name
-  topic_name            = local.evidenceshare_topic_name
+  source              = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=master"
+  name                = local.evidenceshare_subscription_name
+  namespace_name      = local.servicebus_namespace_name
+  resource_group_name = local.resource_group_name
+  topic_name          = local.evidenceshare_topic_name
 }
 
 module "notifications-subscription" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=master"
-  name                  = local.notifications_subscription_name
-  namespace_name        = local.servicebus_namespace_name
-  resource_group_name   = local.resource_group_name
-  topic_name            = local.evidenceshare_topic_name
+  source              = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=master"
+  name                = local.notifications_subscription_name
+  namespace_name      = local.servicebus_namespace_name
+  resource_group_name = local.resource_group_name
+  topic_name          = local.evidenceshare_topic_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "location" {
 }
 
 variable "shutterPageDirectory" {
-    default = "shutterPages"
+  default = "shutterPages"
 }
 
 variable "subscription" {}
@@ -41,3 +41,5 @@ variable "jenkins_AAD_objectId" {
 variable "managed_identity_object_id" {
   default = ""
 }
+
+variable "aks_subscription_id" {}


### PR DESCRIPTION
JIRA link (if applicable)
[tools.hmcts.net/jira/browse/DTSPO-6371](https://tools.hmcts.net/jira/browse/DTSPO-6371)

Change description
PlatOps have made some changes to the service bus terraform module, mainly around adding the ability to enable private endpoints. We needed to add a Private Endpoint provider to allow for Private endpoints being deployed to a different Subscription to the Service Bus being created.

This change should have no effect on anything currently deployed, but it will allow you to deploy a Service Bus with a Private Endpoint if you add the correct inputs to the module.

More information on that can be found here: [hmcts/terraform-module-servicebus-namespace#usage](https://github.com/hmcts/terraform-module-servicebus-namespace#usage)

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No