### PR TITLE
Make max message size configurable for topic module

### DIFF
--- a/prod.tfvars
+++ b/prod.tfvars
@@ -63,3 +63,5 @@ sftp_allowed_sa_subnets = [
   // VPN Access
   "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/rg-mgmt/providers/Microsoft.Network/virtualNetworks/core-infra-vnet-mgmt/subnets/sub-vpn-outside"
 ]
+
+max_message_size_in_kilobytes=2048

--- a/prod.tfvars
+++ b/prod.tfvars
@@ -64,4 +64,4 @@ sftp_allowed_sa_subnets = [
   "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/rg-mgmt/providers/Microsoft.Network/virtualNetworks/core-infra-vnet-mgmt/subnets/sub-vpn-outside"
 ]
 
-max_message_size_in_kilobytes=2048
+max_message_size_in_kilobytes = 2048

--- a/servicebus.tf
+++ b/servicebus.tf
@@ -29,6 +29,7 @@ module "evidenceshare-topic" {
   requires_duplicate_detection            = true
   duplicate_detection_history_time_window = "PT1H"
   max_size_in_megabytes                   = 2048
+  max_message_size_in_kilobytes           = var.max_message_size_in_kilobytes
 }
   
 module "evidenceshare-subscription" {

--- a/variables.tf
+++ b/variables.tf
@@ -73,3 +73,9 @@ variable "monitor_action_group" {
 variable "monitor_metric_alerts" {
   default = {}
 }
+
+variable "max_message_size_in_kilobytes" {
+  type        = string
+  description = "Integer value which controls the maximum size of a message allowed on the topic for Premium SKU"
+  default     = null
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCSCI-153

### Change description ###

-  In SSCS we are seeing our callback orchestrator fails to post messages on the topic as they sometimes exceeds 1MB limit. 
- Although we don't want to post such large data on the queue in the short term we want to increase the size slightly till we have strategic fix otherwise it keeps failing and takes lot of effort and time to resolve it manually.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
